### PR TITLE
Make NAG compatible to Debian Buster

### DIFF
--- a/index.cgi
+++ b/index.cgi
@@ -17,7 +17,7 @@
 # NAG - Net.Art Generator (updated version as of 2017)
 #
 # Co-Author: Winnie Soon <rwx[at]siusoon.net>
-# Last: 11.09.2018
+# Last: 17.07.2019
 # Web: www.siusoon.net
 #
 # 1. fixed Google search API: request, retrieval, parsing of image search and error code checking
@@ -28,6 +28,7 @@
 # 6. remove 1000 max width as tested with no different with the others
 # 7. change from http to https for security reasons as per iap suggestions
 # 8. update the error message for the daily limit of google queries
+# 9. Update for the removal of JSON: PARSE due to server upgrade in iap
 #--------------------------------------------------------------
 
 use strict;
@@ -39,6 +40,7 @@ use POSIX;
 use HTTP::Request;
 
 use JSON;
+# use JSON::Parse;
 use warnings;
 use Encode;
 
@@ -62,8 +64,8 @@ my $comment="<!--
 # NAG - Net.Art Generator (updated version with Google API fixed + others)
 #
 # Co-Author: Winnie Soon <rwx[at]siusoon.net>
-# Last: 11.12.2017
-# Using : JSON v". $JSON::VERSION .", JSON::Parse v". $JSON::Parse::VERSION ."
+# Last: 17.07.2019
+# Using : JSON v". $JSON::VERSION ."
 #
 # Web: www.siusoon.net
 -->

--- a/index.cgi
+++ b/index.cgi
@@ -39,7 +39,6 @@ use POSIX;
 use HTTP::Request;
 
 use JSON;
-use JSON::Parse;
 use warnings;
 use Encode;
 


### PR DESCRIPTION
It seems that `JSON::Parse` is included in `JSON` in Debian Buster, therefore the include fails.

This hotfix only removes the line the script worked again (at least it passed my small test).

@siusoon The server already has this change applied, please verify if this change breaks anything on your side. Else it should be safe to merge.

**Edit:** As a reference, these are the version changes:

| Package | stretch | buster |
| :--- | :--- | :--- |
| perl | 5.24.1-3+deb9u5 | 5.28.1-6 |
| libjson-perl | 2.90-1 | 4.02000-1 |

I was not yet able to pinpoint the actual release or commit which brought this change, but I suspect it is in `libjson-perl` because of the the major version bumps.